### PR TITLE
Remove the unnecessary import

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 plugins {
-    id "org.sonarqube" version "5.0.0.4638"
+    id "org.sonarqube" version "5.1.0.4882"
 }
 
 allprojects {

--- a/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
@@ -34,8 +34,6 @@ package com.jme3.app.state;
 import java.awt.Component;
 
 import com.jme3.app.Application;
-import com.jme3.app.state.AbstractAppState;
-import com.jme3.app.state.AppStateManager;
 import com.jme3.system.AWTFrameProcessor;
 import com.jme3.system.AWTTaskExecutor;
 


### PR DESCRIPTION
description: This PR used to remove the unnecessary import as Same package classes are always implicitly imported. Since the AbstractAppState and AppStateManager classes are in the same package (com.jme3.app.state), we can safely remove these import statements.

link to issue: https://github.com/aditya235cu/jmonkeyengineFall2024/issues/14

location:
path: jme3-desktop/.../main/java/com/jme3/app/state/AWTComponentAppState.java
file: AWTComponentAppState.java