### PR TITLE
Remove unnecessary import statement for AbstractAppState (Issue-#33)

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
@@ -34,7 +34,6 @@ package com.jme3.app.state;
 import java.awt.Component;
 
 import com.jme3.app.Application;
-import com.jme3.app.state.AbstractAppState;
 import com.jme3.app.state.AppStateManager;
 import com.jme3.system.AWTFrameProcessor;
 import com.jme3.system.AWTTaskExecutor;


### PR DESCRIPTION
**Description:**
This pull request addresses Issue-#33 by removing the import statement for the class AbstractAppState in AWTComponentAppState.java. The import was unnecessary because classes within the same package are implicitly imported in Java, leading to unnecessary clutter in the code.

**Changes Made:**
Removed the following import statement:
import com.jme3.app.state.AbstractAppState;

This change improves the overall readability and maintainability of the code by ensuring that only necessary imports are present. By reducing technical debt related to redundant code, we align the project with best practices for clean and efficient Java programming.