### PR TITLE
Refactor AWTTaskExecutor constructor to use diamond operator

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/AWTTaskExecutor.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTTaskExecutor.java
@@ -67,7 +67,7 @@ public class AWTTaskExecutor {
   private final List<Runnable> waitTasks;
 
   private AWTTaskExecutor() {
-    waitTasks = new LinkedList<Runnable>();
+    waitTasks = new LinkedList<>();
   }
 
   public List<Runnable> getWaitingTasks(){


### PR DESCRIPTION
This pull request addresses Issue-#56 by refactoring the constructor of the AWTTaskExecutor class. The goal is to improve code readability and adhere to modern Java coding practices.

**Changes Made:**

The constructor was updated to replace the explicit type parameter in the LinkedList initialization with the diamond operator.

**Benefits of the Changes:**

- Improved Readability: Reduces verbosity and enhances clarity by eliminating redundant type declarations.
- Code Maintenance: Aligns the code with contemporary Java standards, making it easier to read and maintain while ensuring type safety.