### PR TITLE
Updated code in CursorLoader.java to handle icon parsing improvements

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
@@ -263,6 +263,17 @@ public class CursorLoader implements AssetLoader {
         return jmeCursor;
     }
 
+    private int getColorFromImage(byte[] icoImage, int colorTableOffset, int index) {
+        int rgb = 0;
+        rgb |= (ubyte(icoImage[colorTableOffset + index * 4 + 2]));
+        rgb <<= 8;
+        rgb |= (ubyte(icoImage[colorTableOffset + index * 4 + 1]));
+        rgb <<= 8;
+        rgb |= (ubyte(icoImage[colorTableOffset + index * 4]));
+        return rgb;
+    }
+
+
     private BufferedImage[] parseICOImage(byte[] icoImage) throws IOException {
         /*
          * Most of this is original code by Jeff Friesen at
@@ -398,15 +409,7 @@ public class CursorLoader implements AssetLoader {
                                 index = 0;
                             }
 
-                            int rgb = 0;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4
-                                    + 2]));
-                            rgb <<= 8;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4
-                                    + 1]));
-                            rgb <<= 8;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index
-                                    * 4]));
+                            int rgb = getColorFromImage(icoImage, colorTableOffset, index);
 
                             if ((ubyte(icoImage[andImageOffset + row
                                     * scanlineBytes + col / 8])
@@ -440,15 +443,7 @@ public class CursorLoader implements AssetLoader {
                                         & 15;
                             }
 
-                            int rgb = 0;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4
-                                    + 2]));
-                            rgb <<= 8;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4
-                                    + 1]));
-                            rgb <<= 8;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index
-                                    * 4]));
+                            int rgb = getColorFromImage(icoImage, colorTableOffset, index);
 
                             if ((ubyte(icoImage[andImageOffset + row
                                     * calcScanlineBytes(width, 1)
@@ -475,14 +470,7 @@ public class CursorLoader implements AssetLoader {
                             index = ubyte(icoImage[xorImageOffset + row
                                     * scanlineBytes + col]);
 
-                            int rgb = 0;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4
-                                    + 2]));
-                            rgb <<= 8;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4
-                                    + 1]));
-                            rgb <<= 8;
-                            rgb |= (ubyte(icoImage[colorTableOffset + index * 4]));
+                            int rgb = getColorFromImage(icoImage, colorTableOffset, index);
 
                             if ((ubyte(icoImage[andImageOffset + row
                                     * calcScanlineBytes(width, 1)


### PR DESCRIPTION
This issue addresses the duplication of code responsible for parsing RGB values from an ICO image file in the CursorLoader.java class. The code repeats the same logic in multiple places, making it harder to maintain and prone to errors if changes are required. By refactoring the code into a single method, we can eliminate redundancy and centralize the logic for easier updates. The proposed solution is to create a utility method that converts color data based on an index and color table offset. This refactor improves code clarity, reduces duplication, and enhances long-term maintainability.
rilling#95